### PR TITLE
chore: not publish index.ts

### DIFF
--- a/packages/browser/.npmignore
+++ b/packages/browser/.npmignore
@@ -3,4 +3,5 @@ src/*
 cli/*
 scripts/*
 .turbo
+index.ts
 tsconfig.json


### PR DESCRIPTION
The `index.ts` file is [published in npm](https://www.npmjs.com/package/@lightpanda/browser?activeTab=code), but it isn't used. Only the files in the `dist/` (including the `index.cjs`, `index.d.ts` and `index.js` files) directory are needed.